### PR TITLE
修复最后一轮特殊卡得分的计时问题

### DIFF
--- a/GodotVersion/Scripts/Managers/GameInstance.gd
+++ b/GodotVersion/Scripts/Managers/GameInstance.gd
@@ -382,6 +382,13 @@ func _process_action_resolution_async(player: Player, action_cards: Array) -> vo
 
 	var skill_result = await skill_manager.resolve_turn_skills(player, opponent, action_cards_typed)
 	stage_events.append_array(_convert_skill_events_to_display(skill_result.get("events", [])))
+
+	# issue#42: 先完成技能登记（尤其是“增加分数-故事”），再结算故事，
+	# 避免最后一回合故事先结算导致加分技能错过触发窗口。
+	var has_new_story = player.check_finish_story()
+	if has_new_story:
+		await player.new_story_show_finished
+
 	stage_events.append_array(_consume_pending_score_events_for_player(player))
 
 	if not stage_events.is_empty():

--- a/GodotVersion/Scripts/Objects/Player.gd
+++ b/GodotVersion/Scripts/Objects/Player.gd
@@ -909,9 +909,6 @@ func handle_card_selection(player_choosing_card: Card, public_choosing_card: Car
 	await _execute_card_animations(player_choosing_card, acquired_public_card, target_pos, anim_duration, game_instance)
 	_update_player_data(player_choosing_card, acquired_public_card)
 	await _wait_for_animation_complete(anim_duration)
-	var has_new_story = check_finish_story()
-	if has_new_story:
-		await new_story_show_finished
 	InputManager.get_instance().allow_input()
 	action_resolution_completed.emit(self, [player_choosing_card, acquired_public_card])
 


### PR DESCRIPTION
调整技能注册流程，确保"增加分数 - 故事"技能在解析故事完成之前注册。此更改可防止该技能在最后一轮错过触发窗口，从而避免玩家分数丢失。

Fixes #42