### PR TITLE
fix: 修复issue41并支持debug定向发牌

### DIFF
--- a/GodotVersion/Scripts/Debug/DebugController.gd
+++ b/GodotVersion/Scripts/Debug/DebugController.gd
@@ -18,7 +18,7 @@ static func get_instance() -> DebugController:
 # ============================================================
 
 ## 保证指定的基础卡（通过 BaseID）一定分到玩家A手中
-var force_card_to_player_a_enabled: bool = true
+var force_card_to_player_a_enabled: bool = false
 
 ## 要强制分给玩家A的卡牌 BaseID（303 = 云无月）
 var force_card_to_player_a_base_id: int = 303
@@ -27,3 +27,11 @@ var force_card_to_player_a_base_id: int = 303
 ## - 仅影响技能类型判定，不修改数据表原始内容
 ## - 推荐仅在调试时开启
 var force_all_special_skills_to_exchange_enabled: bool = false
+
+## 保证指定卡牌ID一定分到玩家A手中
+## - 仅影响开局发牌
+## - 会优先在玩家A发牌轮次发出以下卡牌
+var force_specific_cards_to_player_a_enabled: bool = true
+
+## 要强制分给玩家A的卡牌ID列表
+var force_specific_cards_to_player_a_ids: Array[int] = [205, 224, 225, 226]

--- a/GodotVersion/Scripts/Managers/CardManager.gd
+++ b/GodotVersion/Scripts/Managers/CardManager.gd
@@ -106,17 +106,28 @@ func shuffle_cardIDs() -> void:
 func send_cards_for_play(cards: Array, game_instance):
 	game_instance_ref = game_instance
 	
-	# Debug: 保证指定卡牌分到玩家A手中
+	# Debug: 强制将指定卡牌分到玩家A
 	var debug_ctrl = _DebugController.get_instance()
+	var forced_player_a_cards: Array[Card] = []
+
 	if debug_ctrl.force_card_to_player_a_enabled:
 		var target_base_id = debug_ctrl.force_card_to_player_a_base_id
-		for i in range(cards.size()):
-			if cards[i].BaseID == target_base_id:
-				var target_card = cards[i]
-				cards.remove_at(i)
-				cards.append(target_card)  # 移到末尾，pop_back 时第一个弹出 (i=0) → player_a
-				print("[Debug] 强制将卡牌 BaseID=%d 分配给玩家A" % target_base_id)
-				break
+		var target_card = _pop_card_by_base_id_from_array(cards, target_base_id)
+		if target_card != null:
+			forced_player_a_cards.append(target_card)
+			print("[Debug] 强制将卡牌 BaseID=%d 分配给玩家A" % target_base_id)
+		else:
+			push_warning("[Debug] 未找到 BaseID=%d，无法强制分配给玩家A" % target_base_id)
+
+	if debug_ctrl.force_specific_cards_to_player_a_enabled:
+		for raw_card_id in debug_ctrl.force_specific_cards_to_player_a_ids:
+			var target_card_id := int(raw_card_id)
+			var forced_card = _pop_card_by_id_from_array(cards, target_card_id)
+			if forced_card != null:
+				forced_player_a_cards.append(forced_card)
+				print("[Debug] 强制将卡牌 ID=%d 分配给玩家A" % target_card_id)
+			else:
+				push_warning("[Debug] 未找到 ID=%d，无法强制分配给玩家A" % target_card_id)
 	
 	# 阶段1: 准备要动画的卡牌数据
 	var cards_to_deal = []  # 存储所有需要发牌的数据
@@ -124,7 +135,14 @@ func send_cards_for_play(cards: Array, game_instance):
 	# 处理玩家手牌
 	for i in range(player_a.hand_cards_pos_array.size() + player_b.hand_cards_pos_array.size()):
 		# A和B玩家轮流发牌
-		var card = cards.pop_back()
+		var card: Card = null
+		if i % 2 == 0 and not forced_player_a_cards.is_empty():
+			card = forced_player_a_cards.pop_front()
+		else:
+			card = cards.pop_back()
+		if card == null:
+			push_error("发牌失败：牌库中的卡牌不足")
+			return
 		if i % 2 == 0:
 			cards_to_deal.append({"card": card, "position": player_a.hand_cards_pos_array.pop_front()})
 			var index:int = player_a.get_player_first_enpty_hand_card_index()
@@ -150,6 +168,22 @@ func send_cards_for_play(cards: Array, game_instance):
 	
 	# 开始发牌动画
 	_start_card_dealing_sequence(cards_to_deal)
+
+func _pop_card_by_base_id_from_array(cards: Array, target_base_id: int) -> Card:
+	for i in range(cards.size() - 1, -1, -1):
+		var card: Card = cards[i]
+		if card != null and card.BaseID == target_base_id:
+			cards.remove_at(i)
+			return card
+	return null
+
+func _pop_card_by_id_from_array(cards: Array, target_card_id: int) -> Card:
+	for i in range(cards.size() - 1, -1, -1):
+		var card: Card = cards[i]
+		if card != null and (card.ID == target_card_id or card.BaseID == target_card_id):
+			cards.remove_at(i)
+			return card
+	return null
 
 ## 开始发牌动画序列
 func _start_card_dealing_sequence(cards_to_deal: Array):

--- a/GodotVersion/Scripts/Managers/ScoreManager.gd
+++ b/GodotVersion/Scripts/Managers/ScoreManager.gd
@@ -380,7 +380,7 @@ func apply_score_effects(player: Player) -> void:
 				if effect.applied_targets[target_id]:
 					continue
 					
-				if player.finished_stories.has(target_id):
+				if player.check_story_in_finished_stories(target_id):
 					# 记录此目标已应用
 					effect.applied_targets[target_id] = true
 					_apply_single_effect(player, effect, target_id)


### PR DESCRIPTION
- 修复 MULTI_STORIES 加分判定使用错误容器导致‘包含自身’不触发\n- 新增并接入 debug 开关：可强制将指定卡牌ID分配给玩家A\n- 发牌逻辑改为玩家A回合优先发放强制卡，并补充缺卡告警